### PR TITLE
Module args improvement

### DIFF
--- a/configs/modules.config
+++ b/configs/modules.config
@@ -13,4 +13,8 @@ process {
         // -r : Print raw output
         ext.args = '-r'
     }
+    withName: 'PRANK' {
+        ext.args  = '-codon -once -F'
+        ext.args2 = '-convert -f=paml -keep'
+    }
 }

--- a/configs/modules.config
+++ b/configs/modules.config
@@ -1,7 +1,16 @@
+/*
 params {
     modules {
         'jq' {
             args = '-r'
         }
+    }
+}
+*/
+
+process {
+    withName: 'JQ' {
+        // -r : Print raw output
+        ext.args = '-r'
     }
 }

--- a/main.nf
+++ b/main.nf
@@ -19,11 +19,11 @@ if(workflow.profile == "uppmax" && !params.project){
     exit 1, "Please provide a SNIC project number ( --project )!\n"
 }
 
-include { SANITIZE_STOP_CODONS } from './modules/sanitize_stop_codons' addParams(options:[:])
-include { PRANK                } from './modules/prank'                addParams(options:[:])
-include { PAML                 } from './modules/paml'                 addParams(options:[:])
-include { HYPHY                } from './modules/hyphy'                addParams(options:[:])
-include { JQ                   } from './modules/jq'                   addParams(options:params.modules['jq'])
+include { SANITIZE_STOP_CODONS } from './modules/sanitize_stop_codons'
+include { PRANK                } from './modules/prank'
+include { PAML                 } from './modules/paml'
+include { HYPHY                } from './modules/hyphy'
+include { JQ                   } from './modules/jq'
 
 // The main workflow
 workflow {

--- a/modules/hyphy.nf
+++ b/modules/hyphy.nf
@@ -17,8 +17,9 @@ process HYPHY {
     path "*.json", emit: json
 
     script:
+    def args = task.ext.args ?: ''
     """
-    hyphy $test --alignment $fasta --tree $tree
+    hyphy $args $test --alignment $fasta --tree $tree
     """
 
 }

--- a/modules/jq.nf
+++ b/modules/jq.nf
@@ -18,8 +18,9 @@ process JQ {
     path "*.tsv", emit: tsv
 
     script:
+    def args = task.ext.args ?: ''
     """
-    jq ${params.options.args} \\
+    jq $args \\
         -f ${jq_filter} \\
         $json > ${json.baseName}.tsv
     """

--- a/modules/prank.nf
+++ b/modules/prank.nf
@@ -18,12 +18,14 @@ process PRANK {
 
     script:
     def prefix = sequences.baseName
+    def args   = task.ext.args  ?: ''
+    def args2  = task.ext.args2 ?: ''
     """
     prank -d=$sequences \\
         -t=$tree \\
         -o=${prefix} \\
-        -codon -once -F
-    prank -convert -f=paml -keep \\
+        $args
+    prank $args2 \\
         -d=${prefix}.best.fas \\
         -o=${prefix}
     """


### PR DESCRIPTION
Remove `params.modules`.
Supply tool specific parameters using `ext.args` and process selectors
```
process {
    withName: 'JQ' {
        ext.args = '-r'
    }
}
```
Allow ext.args for `JQ`, `PRANK`, and `HYPHY`.